### PR TITLE
Add centralized video status constants and expand retry filter

### DIFF
--- a/process-video-30.ts
+++ b/process-video-30.ts
@@ -1,12 +1,13 @@
 import { processYouTubeVideo } from './server/services/videoProcessor';
 import { storage } from './server/storage';
+import { VIDEO_STATUS } from '@shared/schema';
 
 async function processVideo30() {
   try {
     console.log("Processing video #30...");
     
     // Update status to uploading first
-    await storage.updateVideoStatus(30, 'uploading');
+    await storage.updateVideoStatus(30, VIDEO_STATUS.UPLOADING);
     
     // Process the video
     await processYouTubeVideo(

--- a/reprocess-video-29.ts
+++ b/reprocess-video-29.ts
@@ -1,5 +1,6 @@
 import { processYouTubeVideo } from './server/services/videoProcessor';
 import { storage } from './server/storage';
+import { VIDEO_STATUS } from '@shared/schema';
 
 async function reprocessVideo29() {
   try {
@@ -11,7 +12,7 @@ async function reprocessVideo29() {
     );
     
     // Update status
-    await storage.updateVideoStatus(29, 'uploading');
+    await storage.updateVideoStatus(29, VIDEO_STATUS.UPLOADING);
     
     // Process with fixed extraction
     await processYouTubeVideo(

--- a/server/services/videoProcessor.ts
+++ b/server/services/videoProcessor.ts
@@ -2,6 +2,7 @@ import multer from "multer";
 import path from "path";
 import fs from "fs";
 import { storage } from "../storage";
+import { VIDEO_STATUS } from "@shared/schema";
 import { analyzeLacrosseVideo, analyzeLacrosseVideoFromYouTube } from "./gemini";
 import { generateVideoThumbnail, getVideoMetadata, getYouTubeThumbnail } from "./thumbnailGenerator";
 import { AdvancedVideoAnalyzer } from "./advancedVideoAnalysis";
@@ -63,7 +64,7 @@ export async function processVideoUpload(
     console.log(`Starting video processing for video ${videoId}: ${title}`);
     
     // Update video status to processing
-    await storage.updateVideoStatus(videoId, "processing");
+    await storage.updateVideoStatus(videoId, VIDEO_STATUS.PROCESSING);
     
     // Get video metadata
     console.log(`Getting video metadata for ${filePath}`);
@@ -220,18 +221,18 @@ export async function processVideoUpload(
     } catch (analysisError) {
       console.error("Error during two-phase analysis:", analysisError);
       // Update video status to failed on error
-      await storage.updateVideoStatus(videoId, "failed");
+      await storage.updateVideoStatus(videoId, VIDEO_STATUS.FAILED);
       throw analysisError;
     }
     
     // Update video status to completed
-    await storage.updateVideoStatus(videoId, "completed");
+    await storage.updateVideoStatus(videoId, VIDEO_STATUS.COMPLETED);
     console.log(`Video ${videoId} processing completed successfully`);
     
   } catch (error) {
     console.error("Error processing video:", error);
     // Update video status to failed
-    await storage.updateVideoStatus(videoId, "failed");
+    await storage.updateVideoStatus(videoId, VIDEO_STATUS.FAILED);
     throw error;
   }
 }
@@ -254,7 +255,7 @@ export async function processYouTubeVideo(
     console.log(`Starting YouTube video processing for video ${videoId}: ${title}`);
     
     // Update video status to processing
-    await storage.updateVideoStatus(videoId, "processing");
+    await storage.updateVideoStatus(videoId, VIDEO_STATUS.PROCESSING);
     
     // Extract video ID from URL
     const ytVideoId = YouTubeMetadataService.extractVideoId(youtubeUrl);
@@ -448,12 +449,12 @@ export async function processYouTubeVideo(
     }
 
     // Update video status to completed
-    await storage.updateVideoStatus(videoId, "completed");
+    await storage.updateVideoStatus(videoId, VIDEO_STATUS.COMPLETED);
   } catch (error) {
     console.error(`Error processing YouTube video ${videoId}:`, error);
     console.error(`Full error details:`, error instanceof Error ? error.message : error);
     console.error(`Stack trace:`, error instanceof Error ? error.stack : 'No stack trace');
-    await storage.updateVideoStatus(videoId, "failed");
+    await storage.updateVideoStatus(videoId, VIDEO_STATUS.FAILED);
     throw error;
   }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -10,6 +10,7 @@ import {
   type InsertTeam,
   type Video,
   type InsertVideo,
+  type VideoStatus,
   type Analysis,
   type InsertAnalysis,
   type Player,
@@ -33,7 +34,7 @@ export interface IStorage {
   getUserVideos(userId: string): Promise<Video[]>;
   getAllVideos(): Promise<Video[]>;
   getVideo(id: number): Promise<Video | undefined>;
-  updateVideoStatus(id: number, status: string): Promise<Video>;
+  updateVideoStatus(id: number, status: VideoStatus): Promise<Video>;
   updateVideo(id: number, updates: Partial<Video>): Promise<void>;
   
   // Analysis operations
@@ -106,7 +107,7 @@ export class DatabaseStorage implements IStorage {
     return video;
   }
 
-  async updateVideoStatus(id: number, status: string): Promise<Video> {
+  async updateVideoStatus(id: number, status: VideoStatus): Promise<Video> {
     const [video] = await db
       .update(videos)
       .set({ status, updatedAt: new Date() })

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,6 +17,22 @@ import { relations } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
+export const VIDEO_STATUS = {
+  UPLOADING: "uploading",
+  PROCESSING: "processing",
+  COMPLETED: "completed",
+  FAILED: "failed",
+} as const;
+
+export const VIDEO_STATUS_VALUES = [
+  VIDEO_STATUS.UPLOADING,
+  VIDEO_STATUS.PROCESSING,
+  VIDEO_STATUS.COMPLETED,
+  VIDEO_STATUS.FAILED,
+] as const;
+
+export type VideoStatus = (typeof VIDEO_STATUS_VALUES)[number];
+
 // Session storage table for Replit Auth
 export const sessions = pgTable(
   "sessions",
@@ -59,7 +75,9 @@ export const videos = pgTable("videos", {
   thumbnailUrl: varchar("thumbnail_url"),
   userId: varchar("user_id").notNull().references(() => users.id),
   teamId: integer("team_id").references(() => teams.id),
-  status: varchar("status", { length: 50 }).notNull().default("uploading"), // uploading, processing, completed, failed
+  status: varchar("status", { length: 50 })
+    .notNull()
+    .default(VIDEO_STATUS.UPLOADING), // uploading, processing, completed, failed
   userPrompt: text("user_prompt"), // Custom analysis prompt
   playerNumber: varchar("player_number", { length: 10 }),
   teamName: varchar("team_name", { length: 100 }),


### PR DESCRIPTION
## Summary
- add shared video status constants and type so the schema and services share the same definitions
- update upload/retry flows to use the shared statuses and treat uploading/processing videos as retryable
- tighten service helpers to use the shared constants when mutating status values

## Testing
- npm run check *(fails: existing type errors in client components unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68cb948bd7e483339922283bb1296f64